### PR TITLE
 * Removed globalstack value from cache

### DIFF
--- a/lib/HTML/Template/Compiled.pm
+++ b/lib/HTML/Template/Compiled.pm
@@ -1157,6 +1157,7 @@ sub prepare_for_cache {
     $self->set_parser(undef);
     $self->set_compiler(undef);
     $self->set_args(undef);
+    $self->set_globalstack(undef);
 }
 
 sub preload {

--- a/lib/HTML/Template/Compiled/Compiler.pm
+++ b/lib/HTML/Template/Compiled/Compiler.pm
@@ -1140,10 +1140,11 @@ EOM
             my $var = $attr->{NAME};
             $var = '' unless defined $var;
             #print STDERR "============ IF ($text)\n";
-            $code .= "\}" . ($tname eq 'WITH' ? "\}" : '') . qq{\n};
+            $code .= "\}" ;
             if ($self->get_global_vars && $tname eq 'WITH') {
-                $code .= $indent . qq#\$t->popGlobalstack;\n#;
+                $code .= qq{\n} . $indent . qq#\$t->popGlobalstack;\n#;
             }
+            $code .= ($tname eq 'WITH' ? "\}" : '') . qq{\n};
         }
 
         # --------- / TMPL_SWITCH
@@ -1163,12 +1164,11 @@ EOM
             if ($self->get_use_query) {
                 pop @$info_stack;
             }
-            $code .= "\}\n\} # end loop\n";
+            $code .= "\}";
             if ($self->get_global_vars) {
-            $code .= <<"EOM";
-${indent}\$t->popGlobalstack;
-EOM
+                $code .= qq{\n} . $indent . qq#\$t->popGlobalstack;\n#;
             }
+            $code .= "\} # end loop\n";
         }
         elsif ($tname eq T_WRAPPER) {
             $code .= $wrapped[-1];

--- a/t/08_global_vars.t
+++ b/t/08_global_vars.t
@@ -68,6 +68,7 @@ EOM
 __DATA__
 global: <tmpl_var global>
 <tmpl_loop outer>
+ <tmpl_with undefined1></tmpl_with><tmpl_loop undefined2></tmpl_loop><tmpl_if undefined3></tmpl_if><tmpl_unless undefined4></tmpl_unless>
  loopvar: <tmpl_var loopvar>
  global: <tmpl_var global>
  included: <tmpl_include include_w_global.htc >


### PR DESCRIPTION

This is a pull request about issue "H::T::C stores globalstack into cache files" https://github.com/perlpunk/HTML-Template-Compiled/issues/5