### PR TITLE
 * Fix: Globalstack is corrupted when trying to TMPL_LOOP on undefined values.

### DIFF
--- a/lib/HTML/Template/Compiled/Compiler.pm
+++ b/lib/HTML/Template/Compiled/Compiler.pm
@@ -1140,10 +1140,11 @@ EOM
             my $var = $attr->{NAME};
             $var = '' unless defined $var;
             #print STDERR "============ IF ($text)\n";
-            $code .= "\}" . ($tname eq 'WITH' ? "\}" : '') . qq{\n};
+            $code .= "\}" ;
             if ($self->get_global_vars && $tname eq 'WITH') {
-                $code .= $indent . qq#\$t->popGlobalstack;\n#;
+                $code .= qq{\n} . $indent . qq#\$t->popGlobalstack;\n#;
             }
+            $code .= ($tname eq 'WITH' ? "\}" : '') . qq{\n};
         }
 
         # --------- / TMPL_SWITCH
@@ -1163,12 +1164,11 @@ EOM
             if ($self->get_use_query) {
                 pop @$info_stack;
             }
-            $code .= "\}\n\} # end loop\n";
+            $code .= "\}";
             if ($self->get_global_vars) {
-            $code .= <<"EOM";
-${indent}\$t->popGlobalstack;
-EOM
+                $code .= qq{\n} . $indent . qq#\$t->popGlobalstack;\n#;
             }
+            $code .= "\} # end loop\n";
         }
         elsif ($tname eq T_WRAPPER) {
             $code .= $wrapped[-1];

--- a/t/08_global_vars.t
+++ b/t/08_global_vars.t
@@ -68,6 +68,7 @@ EOM
 __DATA__
 global: <tmpl_var global>
 <tmpl_loop outer>
+ <tmpl_with undefined1></tmpl_with><tmpl_loop undefined2></tmpl_loop><tmpl_if undefined3></tmpl_if><tmpl_unless undefined4></tmpl_unless>
  loopvar: <tmpl_var loopvar>
  global: <tmpl_var global>
  included: <tmpl_include include_w_global.htc >


### PR DESCRIPTION

Hi Tina!

I have found another issue in H::T::C. Please look into it. Thanks.

HTC generate the following code for TMPL_LOOP now:

 if (my @array = eval { @${ \$t->try_global($$C, 'UNEXISTENT') } } ){
          $t->pushGlobalstack( $$C);
          [...cut ...]
}
} # end loop
$t->popGlobalstack;

So, there are conditions exists then popGlobalstack() will be called without appropriate pushGlobalstack() and globalstack gets corrupted.  
t/08_global_vars.t updated to check such conditions.

I want to propose patch to fix this issue. Also some cosmetic changes was applied to same push/pop calls on TMPL_IF/TMPL_WITH - now pushGlobalstack() and popGlobalstack() are in the same {} block.

Thanks!

Regards,
Pavel.